### PR TITLE
Added tests for domain error exception and added fixes

### DIFF
--- a/circlify.py
+++ b/circlify.py
@@ -149,11 +149,11 @@ def get_intersection(circle1, circle2):
         log.debug('no solution, the circles are separate: %s, %s',
                   circle1, circle2)
         return None, None
-    if d < abs(r1 - r2):
+    if 1e-9 > d - abs(r1 - r2):
         log.debug('no solution, circles contained within each other: %s, %s',
                   circle1, circle2)
         return None, None
-    if d == 0 and r1 == r2:
+    if math.isclose(d, 0, abs_tol=1e-9) and math.isclose(r1, r2):
         log.debug('no solution, circles are coincident: %s, %s',
                   circle1, circle2)
         return None, None

--- a/tests.py
+++ b/tests.py
@@ -567,6 +567,18 @@ class HedgeTestCase(unittest.TestCase):
         )
         self.assertEqual(3, len(actual))
 
+class GetIntersectionTestCase(unittest.TestCase):
+    def test_one_contained_inside_other(self):
+        """Testing for numerical problems with floating point math"""
+        c1 = circ._Circle(
+                x=-0.005574001032652584,
+                y=0.10484176298731643,
+                r=0.05662982038967889)
+        c2 = circ._Circle(
+                x=0.029345054623395653,
+                y=0.06025929883988402,
+                r=2.220446049250313e-15)
+        self.assertEqual(circ.get_intersection(c1 ,c2), (None,None))
 
 if __name__ == "__main__":
     import logging


### PR DESCRIPTION
The check for "no solution, circles contained within each other" has some mild numerical problems. Certain values will lead to the square root on line 161 throwing a domain error from negative values. The added test results in a value of approximately `-2e-15` which I would assume is close enough to zero to not matter. I also added the use of `math.isclose` in the check on line 156 which will require python version 3.5 or higher. 